### PR TITLE
[ADH-3951] Bump spark to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,40 +8,38 @@
     <artifactId>sparkcube</artifactId>
     <version>0.4.0-SNAPSHOT</version>
 
-    <repositories>
-        <repository>
-            <id>swoop-inc</id>
-            <url>https://dl.bintray.com/swoop-inc/maven/</url>
-        </repository>
-    </repositories>
+    <properties>
+        <spark.version>3.3.2</spark.version>
+        <scala.version>2.13.8</scala.version>
+        <scala.binaryVersion>2.13</scala.binaryVersion>
+        <jackson.version>2.13.4</jackson.version>
+        <jackson.databind.version>2.13.4.2</jackson.databind.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
+        <scalatest.version>3.2.17</scalatest.version>
+        <spark.shade.packageName>org.sparkproject</spark.shade.packageName>
+        <java.version>1.8</java.version>
+    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.7.3</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.5.4</version>
+            <version>${jackson.databind.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.7</version>
+            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.7</version>
+            <version>${jackson.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -55,21 +53,15 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>2.11.12</version>
+            <version>${scala.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
-            <version>3.0.3</version>
+            <artifactId>scalatest_${scala.binaryVersion}</artifactId>
+            <version>${scalatest.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.swoop</groupId>
-            <artifactId>spark-alchemy_2.11</artifactId>
-            <version>0.3.28</version>
         </dependency>
 
         <dependency>
@@ -88,85 +80,49 @@
 
         <dependency> <!-- Spark dependency -->
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.11</artifactId>
+            <artifactId>spark-sql_${scala.binaryVersion}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency> <!-- Spark dependency -->
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.11</artifactId>
+            <artifactId>spark-hive_${scala.binaryVersion}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency> <!-- Spark dependency -->
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.binaryVersion}</artifactId>
+            <version>${spark.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency> <!-- Spark dependency -->
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binaryVersion}</artifactId>
+            <version>${spark.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency> <!-- Spark dependency -->
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_${scala.binaryVersion}</artifactId>
             <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
-    <properties>
-        <jetty.version>9.4.27.v20200227</jetty.version>
-        <spark.version>2.4.4</spark.version>
-    </properties>
-
-    <profiles>
-        <profile>
-            <id>spark-2.4</id>
-            <!-- default config -->
-        </profile>
-        <profile>
-            <id>spark-2.3.4</id>
-            <properties>
-                <spark.version>2.3.4</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.3.3</id>
-            <properties>
-                <spark.version>2.3.3</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.3.2</id>
-            <properties>
-                <spark.version>2.3.2</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.3.1</id>
-            <properties>
-                <spark.version>2.3.1</spark.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.3.0</id>
-            <properties>
-                <spark.version>2.3.0</spark.version>
-                <jetty.version>9.3.20.v20170531</jetty.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.2</id>
-            <properties>
-                <spark.version>2.2.3</spark.version>
-                <jetty.version>9.3.11.v20160721</jetty.version>
-            </properties>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <!-- 3.3.1 won't work with zinc; fails to find javac from java.home -->
-                <version>3.2.2</version>
+                <version>4.4.0</version>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>
@@ -182,15 +138,16 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <scalaVersion>2.11.12</scalaVersion>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <checkMultipleScalaVersions>true</checkMultipleScalaVersions>
+                    <failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
                     <recompileMode>incremental</recompileMode>
-                    <useZincServer>true</useZincServer>
                     <args>
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-explaintypes</arg>
-                        <arg>-Yno-adapted-args</arg>
+                        <arg>-target:jvm-1.8</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>
@@ -204,6 +161,17 @@
                         <javacArg>${java.version}</javacArg>
                         <javacArg>-Xlint:all,-serial,-path,-try</javacArg>
                     </javacArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <skipMain>true</skipMain> <!-- skip compile -->
+                    <skip>true</skip> <!-- skip testCompile -->
                 </configuration>
             </plugin>
             <plugin>
@@ -314,7 +282,7 @@
                             <relocations>
                                 <relocation>
                                     <pattern>org.eclipse.jetty</pattern>
-                                    <shadedPattern>org.spark_project.jetty</shadedPattern>
+                                    <shadedPattern>${spark.shade.packageName}.jetty</shadedPattern>
                                     <includes>
                                         <include>org.eclipse.jetty.**</include>
                                     </includes>

--- a/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-build-page.js
+++ b/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-build-page.js
@@ -61,8 +61,11 @@ function buildCache() {
     $.ajax({
       url: url,
       type: "PUT",
+      contentType: "application/json",
+      dataType: "json",
       data: JSON.stringify({param: JSON.stringify(buildInfo)}),
       headers: {
+        "Accept": "application/json",
         "Content-Type": "application/json",
         "X-HTTP-Method-Override": "PUT" },
       success: function(response) {
@@ -133,8 +136,11 @@ function periodBuildCache() {
   $.ajax({
     url: url,
     type: "PUT",
+    contentType: "application/json",
+    dataType: "json",
     data: JSON.stringify({param: JSON.stringify(periodBuildInfo)}),
     headers: {
+      "Accept": "application/json",
       "Content-Type": "application/json",
       "X-HTTP-Method-Override": "PUT" },
     success: function(response) {

--- a/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-detail-page.js
+++ b/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-detail-page.js
@@ -27,8 +27,11 @@ $(function() {
       $.ajax({
         url: url,
         type: "PUT",
+        contentType: "application/json",
+        dataType: "json",
         data: JSON.stringify(body),
         headers: {
+            "Accept": "application/json",
             "Content-Type": "application/json",
             "X-HTTP-Method-Override": "PUT" },
         success: function(response) {
@@ -71,7 +74,10 @@ function clearBuildHistory() {
   $.ajax({
     url: url,
     type: "PUT",
+    contentType: "application/json",
+    dataType: "json",
     headers: {
+      "Accept": "application/json",
       "Content-Type": "application/json",
       "X-HTTP-Method-Override": "PUT" },
       success: function(response) {
@@ -95,7 +101,10 @@ function cancelPeriodBuild() {
   $.ajax({
     url: url,
     type: "PUT",
+    contentType: "application/json",
+    dataType: "json",
     headers: {
+      "Accept": "application/json",
       "Content-Type": "application/json",
       "X-HTTP-Method-Override": "PUT" },
       success: function(response) {
@@ -119,8 +128,11 @@ function deleteCachePartition(pathToDelete) {
   $.ajax({
     url: url,
     type: "PUT",
+    contentType: "application/json",
+    dataType: "json",
     data: JSON.stringify({param: pathToDelete}),
     headers: {
+      "Accept": "application/json",
       "Content-Type": "application/json",
       "X-HTTP-Method-Override": "PUT" },
       success: function(response) {

--- a/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-page.js
+++ b/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-page.js
@@ -16,6 +16,8 @@
  */
 
 $(function() {
+    $('#mymodal-data').toggle();
+
     $("span.additional-dimension").click(function() {
         $(this).parent().find('input[type="checkbox"]').trigger('click');
     });

--- a/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-page.js
+++ b/src/main/resources/com/alibaba/sparkcube/execution/ui/static/caching/spark-cube-page.js
@@ -127,8 +127,11 @@ $(function() {
            $.ajax({
                 url: url,
                 type: "PUT",
+                contentType: "application/json",
+                dataType: "json",
                 data: JSON.stringify({param: JSON.stringify(cacheDetail)}),
                 headers: {
+                    "Accept": "application/json",
                     "Content-Type": "application/json",
                     "X-HTTP-Method-Override": "PUT" },
                 success: function(response) {
@@ -174,7 +177,10 @@ function dropCache(cacheId) {
   $.ajax({
     url: url,
     type: "PUT",
+    contentType: "application/json",
+    dataType: "json",
     headers: {
+      "Accept": "application/json",
       "Content-Type": "application/json",
       "X-HTTP-Method-Override": "PUT" },
       success: function(response) {

--- a/src/main/scala/com/alibaba/sparkcube/CubeManager.scala
+++ b/src/main/scala/com/alibaba/sparkcube/CubeManager.scala
@@ -584,10 +584,6 @@ class CubeManager extends Logging {
       case "PRE_COUNT_DISTINCT" | "Pre_Count_Distinct" | "pre_count_distinct" =>
         SparkAgent.createColumn(
           toAlias(PreCountDistinct(col(measure.column).expr).toAggregateExpression, measure))
-      case "PRE_APPROX_COUNT_DISTINCT" | "Pre_Approx_Count_Distinct" |
-           "pre_approx_count_distinct" =>
-        SparkAgent.createColumn(toAlias(
-          PreApproxCountDistinct(col(measure.column).expr).toAggregateExpression, measure))
       case other: String =>
         throw SparkAgent.analysisException(s"Function $other is not support for pre calculation.")
     }

--- a/src/main/scala/com/alibaba/sparkcube/execution/CacheUtils.scala
+++ b/src/main/scala/com/alibaba/sparkcube/execution/CacheUtils.scala
@@ -34,7 +34,7 @@ object CacheUtils {
     plan.find {
       case LogicalRelation(_, _, Some(catalogTable), _) =>
         catalogTable.identifier.equals(table)
-      case HiveTableRelation(catalogTable, _, _) =>
+      case HiveTableRelation(catalogTable, _, _, _, _) =>
         catalogTable.identifier.equals(table)
       case _ => false
     }.nonEmpty
@@ -62,7 +62,8 @@ object CacheUtils {
               if (alias.exprId == namedExpr.exprId) {
                 currentExpr = child match {
                   case ne: NamedExpression => ne
-                  case Cast(grandchild, _, _) if (grandchild.isInstanceOf[NamedExpression]) =>
+                  case Cast(grandchild, _, _, ansiEnabled)
+                    if (grandchild.isInstanceOf[NamedExpression] && ! ansiEnabled) =>
                     grandchild.asInstanceOf[NamedExpression]
                   case _ => currentExpr
                 }
@@ -86,7 +87,7 @@ object CacheUtils {
     plan.collect {
       case LogicalRelation(_, _, Some(catalogTable), _) =>
         catalogTable
-      case HiveTableRelation(catalogTable, _, _) =>
+      case HiveTableRelation(catalogTable, _, _, _, _) =>
         catalogTable
     }
   }

--- a/src/main/scala/com/alibaba/sparkcube/execution/GlobalDictionaryPlaceHolder.scala
+++ b/src/main/scala/com/alibaba/sparkcube/execution/GlobalDictionaryPlaceHolder.scala
@@ -28,7 +28,12 @@ case class GlobalDictionaryPlaceHolder(
 
   override def children: Seq[LogicalPlan] = Seq(child)
 
-  override def simpleString: String = {
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = {
+    copy(child = newChildren.head)
+  }
+
+  override def simpleString(maxFields: Int): String = {
     s"GlobalDictionary (${exprName}, ${output.mkString("[", ",", "]")})"
   }
 }

--- a/src/main/scala/com/alibaba/sparkcube/execution/api/CubeSource.scala
+++ b/src/main/scala/com/alibaba/sparkcube/execution/api/CubeSource.scala
@@ -21,12 +21,15 @@ import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{Context, MediaType}
+
 import org.apache.hadoop.conf.Configuration
 import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.glassfish.jersey.server.ServerProperties
 import org.glassfish.jersey.servlet.ServletContainer
+
 import org.apache.spark.sql.{SaveMode, SparkAgent, SparkSession}
+
 import com.alibaba.sparkcube.CubeManager
 import com.alibaba.sparkcube.catalog.{CubeCacheInfo, RawCacheInfo}
 import com.alibaba.sparkcube.execution.{BuildHistory, PeriodBuildInfo}
@@ -454,7 +457,7 @@ object SparkCubeSource {
 //    val holder: ServletHolder = new ServletHolder(new ServletContainer(config))
     val holder: ServletHolder = new ServletHolder(classOf[ServletContainer])
     holder.setInitParameter(ServerProperties.PROVIDER_CLASSNAMES,
-        "org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider")
+        "com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider")
     holder.setInitParameter(ServerProperties.PROVIDER_PACKAGES,
       "com.alibaba.sparkcube.execution.api")
     CacheRootFromServletContext.setCacheManager(jerseyContext, cacheManager)

--- a/src/main/scala/com/alibaba/sparkcube/execution/api/CubeSource.scala
+++ b/src/main/scala/com/alibaba/sparkcube/execution/api/CubeSource.scala
@@ -21,15 +21,12 @@ import javax.servlet.ServletContext
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.core.{Context, MediaType}
-
 import org.apache.hadoop.conf.Configuration
 import org.eclipse.jetty.server.handler.ContextHandler
 import org.eclipse.jetty.servlet.{ServletContextHandler, ServletHolder}
 import org.glassfish.jersey.server.ServerProperties
 import org.glassfish.jersey.servlet.ServletContainer
-
 import org.apache.spark.sql.{SaveMode, SparkAgent, SparkSession}
-
 import com.alibaba.sparkcube.CubeManager
 import com.alibaba.sparkcube.catalog.{CubeCacheInfo, RawCacheInfo}
 import com.alibaba.sparkcube.execution.{BuildHistory, PeriodBuildInfo}
@@ -457,7 +454,7 @@ object SparkCubeSource {
 //    val holder: ServletHolder = new ServletHolder(new ServletContainer(config))
     val holder: ServletHolder = new ServletHolder(classOf[ServletContainer])
     holder.setInitParameter(ServerProperties.PROVIDER_CLASSNAMES,
-        "com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider")
+        "org.codehaus.jackson.jaxrs.JacksonJaxbJsonProvider")
     holder.setInitParameter(ServerProperties.PROVIDER_PACKAGES,
       "com.alibaba.sparkcube.execution.api")
     CacheRootFromServletContext.setCacheManager(jerseyContext, cacheManager)

--- a/src/main/scala/org/apache/spark/ui/SparkCubeBuildPage.scala
+++ b/src/main/scala/org/apache/spark/ui/SparkCubeBuildPage.scala
@@ -30,9 +30,9 @@ class SparkCubeBuildPage(parent: SparkCubeTab)
   extends AbstractSparkCubePage(parent, "Build") {
 
   override def render(request: HttpServletRequest): Seq[Node] = {
-    val parameterCacheId = UIUtils.stripXSS(request.getParameter("cacheId"))
+    val parameterCacheId = request.getParameter("cacheId")
     require(parameterCacheId != null && parameterCacheId.nonEmpty, "Missing cache id parameter")
-    val action = UIUtils.stripXSS(request.getParameter("action"))
+    val action = request.getParameter("action")
     val cacheId = CacheIdentifier(parameterCacheId)
 
     val fields = sparkSession.sessionState.catalog

--- a/src/main/scala/org/apache/spark/ui/SparkCubeCreatePage.scala
+++ b/src/main/scala/org/apache/spark/ui/SparkCubeCreatePage.scala
@@ -84,13 +84,13 @@ class SparkCubeCreatePage(parent: SparkCubeTab)
   private def checkCacheAction(
       request: HttpServletRequest,
       tableOrView: Seq[TableOrView]): Seq[Node] = {
-    val cacheType = UIUtils.stripXSS(request.getParameter("cacheType"))
-    val createCache = UIUtils.stripXSS(request.getParameter("createCache"))
+    val cacheType = request.getParameter("cacheType")
+    val createCache = request.getParameter("createCache")
     if (cacheType == null || createCache != null) {
       Nil
     } else {
       var popTitle: String = null
-      val tableId = UIUtils.stripXSS(request.getParameter("tableId")).toInt
+      val tableId = request.getParameter("tableId").toInt
       val db = tableOrView(tableId).dataBase
       val table = tableOrView(tableId).tableName
       val fields = tableOrView(tableId).fields
@@ -123,7 +123,6 @@ class SparkCubeCreatePage(parent: SparkCubeTab)
           <option>MIN</option>
           <option>AVERAGE</option>
           <option>PRE_COUNT_DISTINCT</option>
-          <option>PRE_APPROX_COUNT_DISTINCT</option>
         </select>
         <button class="btn btn-info btn-mini" id="" onclick="addMeasure()">+</button>
         <button class="btn btn-info btn-mini" id="" onclick="removeClick(this)">-</button>

--- a/src/main/scala/org/apache/spark/ui/SparkCubeDetailPage.scala
+++ b/src/main/scala/org/apache/spark/ui/SparkCubeDetailPage.scala
@@ -31,7 +31,7 @@ class SparkCubeDetailPage(parent: SparkCubeTab)
   extends AbstractSparkCubePage(parent, "Detail") {
 
   override def render(request: HttpServletRequest): Seq[Node] = {
-    val parameterCacheId = UIUtils.stripXSS(request.getParameter("cacheId"))
+    val parameterCacheId = request.getParameter("cacheId")
     require(parameterCacheId != null && parameterCacheId.nonEmpty,
       "Missing cache id parameter")
 

--- a/src/main/scala/org/apache/spark/ui/SparkCubePage.scala
+++ b/src/main/scala/org/apache/spark/ui/SparkCubePage.scala
@@ -41,10 +41,10 @@ class SparkCubePage(parent: SparkCubeTab)
   override def render(request: HttpServletRequest): Seq[Node] = {
 
     val cacheManager = parent.sharedState.cubeManager
-    val action = UIUtils.stripXSS(request.getParameter("action"))
+    val action = request.getParameter("action")
     if (action != null && action.nonEmpty) {
       if (action == "drop") {
-        val parameterCacheId = UIUtils.stripXSS(request.getParameter("cacheId"))
+        val parameterCacheId = request.getParameter("cacheId")
         require(parameterCacheId != null && parameterCacheId.nonEmpty, "Missing cache id parameter")
         val cacheId = CacheIdentifier(parameterCacheId)
         cacheManager.dropCache(sparkSession, cacheId)

--- a/src/test/resources/plan/join_with_alias
+++ b/src/test/resources/plan/join_with_alias
@@ -1,0 +1,7 @@
+Join Inner, (join_id#74 = cast(group#43 as int))
+:- Project [join_id#74]
+:  +- LocalRelation <empty>, [join_id#74]
++- Project [group#77 AS group#43, num_count#73L AS num_count#73L]
+   +- Project [group#77, num_count#78L AS num_count#73L]
+      +- Project [group#75 AS group#77, num_count#76L AS num_count#78L]
+         +- Relation [group#75,num_count#76L] orc

--- a/src/test/resources/plan/join_with_alias_optimized
+++ b/src/test/resources/plan/join_with_alias_optimized
@@ -1,0 +1,5 @@
+Project [group_name#183, num_count#188L]
++- Join Inner, (group#187 = group_name#183)
+   :- LocalRelation [group_name#183]
+   +- Filter isnotnull(group#187)
+      +- Relation [group#187,num_count#188L] orc

--- a/src/test/resources/plan/projection_on_cache_optimized
+++ b/src/test/resources/plan/projection_on_cache_optimized
@@ -1,0 +1,2 @@
+Project [group#252, num_count#253L]
++- Relation [group#252,num_count#253L,id_count#254L] orc

--- a/src/test/resources/plan/simple_select
+++ b/src/test/resources/plan/simple_select
@@ -1,0 +1,4 @@
+Project [num_count#34L AS num_count#34L]
++- Project [num_count#38L AS num_count#34L]
+   +- Project [group#35 AS group#37, num_count#36L AS num_count#38L]
+      +- Relation [group#35,num_count#36L] orc

--- a/src/test/resources/plan/simple_select_optimized
+++ b/src/test/resources/plan/simple_select_optimized
@@ -1,0 +1,1 @@
+Relation [group#127,num_count#128L] orc

--- a/src/test/scala/com/alibaba/sparkcube/CacheBuildUtils.scala
+++ b/src/test/scala/com/alibaba/sparkcube/CacheBuildUtils.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.sparkcube
+
+import org.apache.spark.sql.SparkSession
+
+import com.alibaba.sparkcube.optimizer.{CacheCubeSchema, CacheFormatInfo, CacheIdentifier, Measure}
+
+trait CacheBuildUtils {
+  protected val cubeManager: CubeManager = new CubeManager()
+
+  protected def spark: SparkSession
+
+  def createDefaultCache(db: String, table: String): Unit = {
+    createAndBuildCache(
+      db = db,
+      table = table,
+      cacheSchema = CacheCubeSchema(
+        dims = Seq("group"),
+        measures = Seq(Measure(
+          column = "num",
+          func = "COUNT"
+        ))
+      )
+    )
+  }
+
+  def createAndBuildCache(db: String, table: String, cacheSchema: CacheCubeSchema): Unit = {
+    val cacheName = s"${table}_cache"
+
+    cubeManager.createCache(spark, s"$db.$table", CacheFormatInfo(
+      cacheName = cacheName,
+      provider = "ORC",
+      cacheSchema = cacheSchema))
+
+    cubeManager.buildCache(spark, CacheIdentifier(
+      db = db,
+      viewName = table,
+      cacheName = cacheName
+    ))
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/RewriteCacheQuerySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/RewriteCacheQuerySuite.scala
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.sql.RewriteCacheQuerySuite.{TEST_DB, TMP_WAREHOUSE_DIR}
+import org.apache.spark.sql.TestUtils.readPlanFromResources
+import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.test.SQLTestUtilsBase
+
+import com.alibaba.sparkcube.{CacheBuildUtils, SparkCube}
+import com.alibaba.sparkcube.optimizer.{CacheCubeSchema, Measure}
+
+class RewriteCacheQuerySuite extends AnyFunSuite
+  with SQLTestUtilsBase
+  with BeforeAndAfterEach
+  with BeforeAndAfterAll
+  with CacheBuildUtils {
+
+  import testImplicits._
+
+  var spark: SparkSession = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    System.clearProperty(IS_TESTING.key)
+    spark = SparkSession
+      .builder()
+      .master("local")
+      .appName("test")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.cache.tab.display", "false")
+      .config("spark.sql.cache.useDatabase", TEST_DB)
+      .config(StaticSQLConf.WAREHOUSE_PATH.key, TMP_WAREHOUSE_DIR.getPath)
+      .withExtensions(new SparkCube())
+      .getOrCreate()
+
+    CubeSharedState.setActiveState(new CubeSharedState(spark))
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    try {
+      spark.sessionState.catalog.reset()
+    } finally {
+      // TestUtils.deleteDirectory(TMP_WAREHOUSE_DIR)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    spark.stop()
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+  }
+
+  test("test rewrite simple select") {
+    val table = "simple_select"
+    withDatabase(TEST_DB) {
+      createTestTable(TEST_DB, table)
+      createDefaultCache(TEST_DB, table)
+
+      val actualPlan = sql(
+        s"""
+           |SELECT group, COUNT(num) AS num_count
+           |FROM $TEST_DB.$table
+           |GROUP BY group
+           |""".stripMargin)
+        .queryExecution
+        .optimizedPlan
+
+      val expectedPlan = readPlanFromResources("simple_select_optimized")
+      assert(expectedPlan == actualPlan.treeString)
+    }
+  }
+
+  test("test rewrite join with alias") {
+    val table = "join_with_alias"
+    withDatabase(TEST_DB) {
+      createTestTable(TEST_DB, table)
+      createDefaultCache(TEST_DB, table)
+
+      Seq("group1", "group2")
+        .toDF("group_name")
+        .createOrReplaceTempView("groups")
+
+      val actualPlan = sql(
+        s"""
+           |SELECT groups.group_name, cached_table.num_count
+           |FROM groups join (
+           |  SELECT group, COUNT(num) AS num_count
+           |  FROM $TEST_DB.$table
+           |  GROUP BY group
+           |) as cached_table
+           |ON cached_table.group = groups.group_name
+           |""".stripMargin)
+        .queryExecution
+        .optimizedPlan
+
+      val expectedPlan = readPlanFromResources("join_with_alias_optimized")
+      assert(expectedPlan == actualPlan.treeString)
+    }
+  }
+
+  test("test support projection on cache") {
+    val table = "uppercase_select"
+    withDatabase(TEST_DB) {
+      createTestTable(TEST_DB, table)
+
+      createAndBuildCache(
+        db = TEST_DB,
+        table = table,
+        cacheSchema = CacheCubeSchema(
+          dims = Seq("group"),
+          measures = Seq(
+            Measure(
+              column = "num",
+              func = "COUNT"
+            ),
+            // additional aggregation
+            Measure(
+              column = "id",
+              func = "COUNT"
+            ))
+        )
+      )
+
+      val actualPlan = sql(
+        s"""
+           |SELECT group, COUNT(num) AS num_count
+           |FROM $TEST_DB.$table
+           |GROUP BY group
+           |""".stripMargin)
+        .queryExecution
+        .optimizedPlan
+
+      val expectedPlan = readPlanFromResources("projection_on_cache_optimized")
+      assert(expectedPlan == actualPlan.treeString)
+    }
+  }
+
+  // TODO support case insensitive column names
+  ignore("test rewrite simple select with uppercase columns") {
+    val table = "uppercase_select"
+    withDatabase(TEST_DB) {
+      createTestTable(TEST_DB, table)
+      createDefaultCache(TEST_DB, table)
+
+      val actualPlan = sql(
+        s"""
+           |SELECT GROUP, COUNT(NUM) AS num_count
+           |FROM $TEST_DB.$table
+           |GROUP BY group
+           |""".stripMargin)
+        .queryExecution
+        .optimizedPlan
+
+      val expectedPlan = readPlanFromResources("simple_select_optimized")
+      assert(expectedPlan == actualPlan.treeString)
+    }
+  }
+
+  private def createTestTable(db: String, table: String): Unit = {
+    sql(s"CREATE DATABASE IF NOT EXISTS $db")
+
+    Seq((1, "group1", 3))
+      .toDF("id", "group", "num")
+      .write
+      .saveAsTable(s"$db.$table")
+  }
+}
+
+object RewriteCacheQuerySuite {
+  val TMP_WAREHOUSE_DIR = TestUtils.createTempDir("warehouse")
+  val TEST_DB = "rewrite_test_db"
+}

--- a/src/test/scala/org/apache/spark/sql/TestUtils.scala
+++ b/src/test/scala/org/apache/spark/sql/TestUtils.scala
@@ -17,19 +17,23 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkContext, SparkFunSuite}
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 
-class CubeSharedStateSuite extends SparkFunSuite {
+import org.apache.spark.util.Utils
 
-  override protected def afterAll(): Unit = {
-    SparkContext.getOrCreate().stop()
-    SparkSession.clearActiveSession()
-    SparkSession.clearDefaultSession()
+object TestUtils {
+  def createTempDir(namePrefix: String = "spark_cache"): File = {
+    Utils.createTempDir(namePrefix = namePrefix)
   }
 
-  test("sharedState init") {
-    val session = SparkSession.builder().master("local").getOrCreate()
-    assert(CubeSharedState.get(session) != null)
+  def deleteDirectory(file: File): Unit = {
+    Utils.deleteRecursively(file)
   }
 
+  def readPlanFromResources(planName: String): String = {
+    val planPath = Paths.get(getClass.getClassLoader.getResource(s"plan/$planName").getPath)
+    new String(Files.readAllBytes(planPath), StandardCharsets.UTF_8)
+  }
 }


### PR DESCRIPTION
- Upgraded scala version to `2.13.8` and spark version to `3.3.2`
- Removed approximate count aggregation support
- Added tests for checking rewrites of queries with aggregations on cached tables 